### PR TITLE
fix: remove space in variable name

### DIFF
--- a/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
+++ b/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
@@ -134,7 +134,7 @@ class KubernetesManifest:
 
     def __post_init__(self):
         """Validate that the manifest content is a valid YAML."""
-        self. manifest = yaml.safe_load(self.manifest_content)
+        self.manifest = yaml.safe_load(self.manifest_content)
 
 
 class KubernetesManifestsUpdatedEvent(RelationEvent):


### PR DESCRIPTION
There was an extra space in `self. manifest = yaml.safe_load(self.manifest_content)`. This PR corrects that.