### PR TITLE
fix: correct manifests relation direction

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,7 +15,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     upstream-source: charmedkubeflow/resource-dispatcher:1.0-22.04
-requires:
+provides:
   secrets:
     interface: kubernetes_manifest
   service-accounts:

--- a/tests/integration/manifests-tester/metadata.yaml
+++ b/tests/integration/manifests-tester/metadata.yaml
@@ -5,7 +5,7 @@ summary: |
   Charm for sending manifests to ResourceDispatcher relations.
 description: |
   Charm for sending manifests to ResourceDispatcher relations.
-provides:
+requires:
   secrets:
     interface: kubernetes_manifest
   service-accounts:


### PR DESCRIPTION
According to the kubernetes_manifests library's docstring, the resource-dispatcher charm should be the provider of the relation, where the charm on the other side should be the requirer.
Due to back and forth conversations about the relation's direction, the direction in the charm's metadata was incorrectly merged in #42 as `requires` where it should be `provides`. The same applies for the tester charm.