### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,7 +64,7 @@ jobs:
       with:
         provider: microk8s
         channel: 1.29-strict/stable
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Run integration tests


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944