### PR TITLE
Feat: Add Terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,7 +56,6 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: .
-      model: kubeflow
       channel: latest/edge
       # Don't run this workflow since the charm goes to `Error` state when deployed on its own
       # See: https://github.com/canonical/resource-dispatcher/issues/66

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -69,7 +69,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
+      uses: charmed-kubernetes/actions-operator@5193238c86d58e874ad3457da2df640ef138a41f
       with:
         provider: microk8s
         channel: 1.29-strict/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -69,7 +69,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@5193238c86d58e874ad3457da2df640ef138a41f
+      uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
         channel: 1.29-strict/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,7 +56,6 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: .
-      channel: latest/edge
       # Don't run this workflow since the charm goes to `Error` state when deployed on its own
       # See: https://github.com/canonical/resource-dispatcher/issues/66
       apply: false

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,6 +58,7 @@ jobs:
       charm-path: .
       model: kubeflow
       channel: latest/edge
+      apply: false
       
   integration:
     name: Integration Test (build and deploy)

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,6 +58,8 @@ jobs:
       charm-path: .
       model: kubeflow
       channel: latest/edge
+      # Don't run this workflow since the charm goes to `Error` state when deployed on its own
+      # See: https://github.com/canonical/resource-dispatcher/issues/66
       apply: false
       
   integration:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,6 +51,14 @@ jobs:
     - name: Run unit tests
       run: tox -e unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: .
+      model: kubeflow
+      channel: latest/edge
+      
   integration:
     name: Integration Test (build and deploy)
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+venv/
+.terraform*
+*.tfstate*
 
 kubeconfig.tmp
 new_config

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for resource-dispatcher
+
+This is a Terraform module facilitating the deployment of the resource-dispatcher charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs) 
+
+## Compatibility
+This terraform module is compatible with charms of version >= ckf-1.9 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "resource_dispatcher" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "resource_dispatcher" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -43,7 +43,7 @@ resource "juju_model" "testing" {
   name = kubeflow
 }
 
-module "resource_dispatcher" {
+module "resource-dispatcher" {
   source = "<path-to-this-directory>"
   model_name = juju_model.testing.name
 }
@@ -56,7 +56,7 @@ data "juju_model" "testing" {
   name = var.model_name
 }
 
-module "resource_dispatcher" {
+module "resource-dispatcher" {
   source = "<path-to-this-directory>"
   model_name = data.juju_model.testing.name
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,9 +2,6 @@
 
 This is a Terraform module facilitating the deployment of the resource-dispatcher charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs) 
 
-## Compatibility
-This terraform module is compatible with charms of version >= 2.0 due to changes in the charm's relations.
-
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,7 +3,7 @@
 This is a Terraform module facilitating the deployment of the resource-dispatcher charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs) 
 
 ## Compatibility
-This terraform module is compatible with charms of version >= ckf-1.9 due to changes in the charm's relations.
+This terraform module is compatible with charms of version >= 2.0 due to changes in the charm's relations.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "resource_dispatcher" {
+  charm {
+    name     = "resource-dispatcher"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,6 +11,5 @@ output "provides" {
 }
 
 output "requires" {
-  value = {
-  }
+  value = {}
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,9 +4,9 @@ output "app_name" {
 
 output "provides" {
   value = {
-	secrets          = "secrets"
-	service_accounts = "service-accounts"
-	pod_defaults     = "pod-defaults"
+    secrets          = "secrets"
+    service_accounts = "service-accounts"
+    pod_defaults     = "pod-defaults"
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,9 +4,9 @@ output "app_name" {
 
 output "provides" {
   value = {
-    secrets          = "secrets"
-    service_accounts = "service-accounts"
-    pod_defaults     = "pod-defaults"
+    secrets          = "secrets",
+    service_accounts = "service-accounts",
+    pod_defaults     = "pod-defaults",
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "app_name" {
+  value = juju_application.resource_dispatcher.name
+}
+
+output "provides" {
+  value = {
+	secrets          = "secrets"
+	service_accounts = "service-accounts"
+	pod_defaults     = "pod-defaults"
+  }
+}
+
+output "requires" {
+  value = {
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "latest/edge"
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = "latest/edge"
+  default     = null
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "resource-dispatcher"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Ref: #63 

This PR creates a `terraform/` directory that hosts the Terraform module for this charm. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit).

To test the module:
- Clone the repository and switch to this branch.
- First run `tox -e tflint` to ensure that linting is correct
- Change to the `terraform/` directory and run `terraform init`.
- Run `terraform apply -var "channel=latest/edge" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.