### PR TITLE
chore: add tools/get-images.sh to gather images from this charm

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
This commit adds the support script for gathering the images this charm uses.

Part of canonical/bundle-kubeflow#1084