### PR TITLE
chore: update python dependencies + pin pip

### DIFF
--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.3.0
+black==24.8.0
     # via -r requirements-fmt.in
-click==8.1.3
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.1
+pathspec==0.12.1
     # via black
-platformdirs==3.5.3
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.6.3
+typing-extensions==4.12.2
     # via black

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,68 +4,78 @@
 #
 #    pip-compile requirements-integration.in
 #
-aiohttp==3.8.5
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.10.11
     # via -r requirements-integration.in
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.12.0
+alembic==1.14.0
     # via mlflow
-anyio==4.0.0
+anyio==4.5.2
     # via
     #   -r requirements.txt
-    #   httpcore
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.0
+    #   httpx
+asttokens==3.0.0
     # via stack-data
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.1.0
+attrs==24.2.0
     # via
     #   -r requirements.txt
     #   aiohttp
     #   jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.0.1
-    # via paramiko
-blinker==1.6.2
+backports-strenum==1.3.1
+    # via
+    #   -r requirements.txt
+    #   juju
+bcrypt==4.2.1
+    # via
+    #   -r requirements.txt
+    #   paramiko
+blinker==1.8.2
     # via flask
-cachetools==5.3.1
-    # via google-auth
-certifi==2023.7.22
+cachetools==5.5.0
+    # via
+    #   -r requirements.txt
+    #   google-auth
+    #   mlflow-skinny
+certifi==2024.8.30
     # via
     #   -r requirements.txt
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.15.1
-    # via
-    #   cryptography
-    #   pynacl
-charmed-kubeflow-chisme==0.2.0
-    # via -r requirements.txt
-charset-normalizer==3.2.0
+cffi==1.17.1
     # via
     #   -r requirements.txt
-    #   aiohttp
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
+    # via -r requirements.txt
+charset-normalizer==3.4.0
+    # via
+    #   -r requirements.txt
     #   requests
 click==8.1.7
     # via
-    #   databricks-cli
     #   flask
-    #   mlflow
-cloudpickle==2.2.1
-    # via mlflow
-contourpy==1.1.0
+    #   mlflow-skinny
+cloudpickle==3.1.0
+    # via mlflow-skinny
+contourpy==1.1.1
     # via matplotlib
-cryptography==41.0.3
-    # via paramiko
-cycler==0.11.0
+cryptography==44.0.0
+    # via
+    #   -r requirements.txt
+    #   paramiko
+cycler==0.12.1
     # via matplotlib
-databricks-cli==0.17.6
-    # via mlflow
+databricks-sdk==0.38.0
+    # via mlflow-skinny
 decorator==5.1.1
     # via
     #   ipdb
@@ -74,61 +84,79 @@ deepdiff==6.2.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-docker==6.1.3
+deprecated==1.2.15
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-semantic-conventions
+docker==7.1.0
     # via mlflow
-entrypoints==0.4
-    # via mlflow
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via
     #   -r requirements.txt
     #   anyio
     #   pytest
-executing==1.2.0
+executing==2.1.0
     # via stack-data
-flask==2.3.3
+flask==3.0.3
     # via mlflow
-fonttools==4.42.1
+fonttools==4.55.1
     # via matplotlib
-frozenlist==1.4.0
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-gitdb==4.0.10
+gitdb==4.0.11
     # via gitpython
-gitpython==3.1.35
+gitpython==3.1.43
+    # via mlflow-skinny
+google-auth==2.36.0
+    # via
+    #   -r requirements.txt
+    #   databricks-sdk
+    #   kubernetes
+graphene==3.4.3
     # via mlflow
-google-auth==2.17.3
-    # via kubernetes
-gunicorn==21.2.0
+graphql-core==3.2.5
+    # via
+    #   graphene
+    #   graphql-relay
+graphql-relay==3.2.0
+    # via graphene
+greenlet==3.1.1
+    # via sqlalchemy
+gunicorn==23.0.0
     # via mlflow
 h11==0.14.0
     # via
     #   -r requirements.txt
     #   httpcore
-httpcore==0.18.0
+httpcore==1.0.7
     # via
     #   -r requirements.txt
     #   httpx
-httpx==0.25.0
+httpx==0.28.0
     # via
     #   -r requirements.txt
     #   lightkube
-hvac==1.2.1
-    # via juju
-idna==3.4
+hvac==2.3.0
+    # via
+    #   -r requirements.txt
+    #   juju
+idna==3.10
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==8.5.0
     # via
     #   alembic
     #   flask
     #   markdown
-    #   mlflow
-importlib-resources==6.0.1
+    #   mlflow-skinny
+    #   opentelemetry-api
+importlib-resources==6.4.5
     # via
     #   -r requirements.txt
     #   alembic
@@ -138,13 +166,13 @@ iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.2
+ipython==8.12.3
     # via ipdb
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via flask
-jedi==0.19.0
+jedi==0.19.2
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   -r requirements-integration.in
     #   -r requirements.txt
@@ -152,52 +180,62 @@ jinja2==3.1.2
     #   flask
     #   mlflow
     #   pytest-operator
-joblib==1.3.2
+joblib==1.4.2
     # via scikit-learn
 jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-juju==3.2.2
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
     #   pytest-operator
-kiwisolver==1.4.5
+kiwisolver==1.4.7
     # via matplotlib
-kubernetes==27.2.0
-    # via juju
-lightkube==0.14.0
+kubernetes==30.1.0
+    # via
+    #   -r requirements.txt
+    #   juju
+lightkube==0.15.5
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-lightkube-models==1.28.1.4
+lightkube-models==1.31.1.8
     # via
     #   -r requirements.txt
     #   lightkube
-macaroonbakery==1.3.1
-    # via juju
-mako==1.2.4
+macaroonbakery==1.3.4
+    # via
+    #   -r requirements.txt
+    #   juju
+mako==1.3.7
     # via alembic
-markdown==3.4.4
+markdown==3.7
     # via mlflow
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
     #   mako
     #   werkzeug
-matplotlib==3.7.2
+matplotlib==3.7.5
     # via mlflow
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
-mlflow==2.6.0
+mlflow==2.17.2
     # via -r requirements-integration.in
-multidict==6.0.4
+mlflow-skinny==2.17.2
+    # via mlflow
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
 mypy-extensions==1.0.0
-    # via typing-inspect
+    # via
+    #   -r requirements.txt
+    #   typing-inspect
 numpy==1.24.4
     # via
     #   contourpy
@@ -209,12 +247,21 @@ numpy==1.24.4
     #   scipy
 oauthlib==3.2.2
     # via
-    #   databricks-cli
+    #   -r requirements.txt
     #   kubernetes
     #   requests-oauthlib
 oci-image==1.0.0
     # via -r requirements.txt
-ops==2.14.0
+opentelemetry-api==1.28.2
+    # via
+    #   mlflow-skinny
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-sdk==1.28.2
+    # via mlflow-skinny
+opentelemetry-semantic-conventions==0.49b2
+    # via opentelemetry-sdk
+ops==2.17.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -223,130 +270,145 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   deepdiff
-packaging==23.1
+packaging==24.2
     # via
-    #   docker
+    #   -r requirements.txt
     #   gunicorn
+    #   juju
     #   matplotlib
-    #   mlflow
+    #   mlflow-skinny
     #   pytest
 pandas==2.0.3
     # via mlflow
-paramiko==2.12.0
-    # via juju
-parso==0.8.3
+paramiko==3.5.0
+    # via
+    #   -r requirements.txt
+    #   juju
+parso==0.8.4
     # via jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==10.0.0
+pillow==10.4.0
     # via matplotlib
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements.txt
     #   jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==3.20.3
+propcache==0.2.0
+    # via yarl
+protobuf==5.29.0
     # via
+    #   -r requirements.txt
     #   macaroonbakery
-    #   mlflow
+    #   mlflow-skinny
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyarrow==12.0.1
+pyarrow==17.0.0
     # via mlflow
-pyasn1==0.5.0
+pyasn1==0.6.1
     # via
+    #   -r requirements.txt
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
-    # via google-auth
-pycparser==2.21
-    # via cffi
-pygments==2.16.1
+pyasn1-modules==0.4.1
+    # via
+    #   -r requirements.txt
+    #   google-auth
+pycparser==2.22
+    # via
+    #   -r requirements.txt
+    #   cffi
+pygments==2.18.0
     # via ipython
-pyhcl==0.4.5
-    # via hvac
-pyjwt==2.8.0
-    # via databricks-cli
 pymacaroons==0.13.0
-    # via macaroonbakery
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
 pynacl==1.5.0
     # via
+    #   -r requirements.txt
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyparsing==3.0.9
+pyparsing==3.1.4
     # via matplotlib
 pyrfc3339==1.1
     # via
+    #   -r requirements.txt
     #   juju
     #   macaroonbakery
-pyrsistent==0.19.3
+pyrsistent==0.20.0
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==7.4.2
+pytest==8.3.4
     # via
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.21.1
+pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
+    #   -r requirements.txt
+    #   graphene
     #   kubernetes
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.2
     # via
-    #   mlflow
+    #   -r requirements.txt
     #   pandas
     #   pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   juju
     #   kubernetes
     #   lightkube
-    #   mlflow
+    #   mlflow-skinny
     #   ops
     #   pytest-operator
     #   serialized-data-interface
-querystring-parser==1.2.4
-    # via mlflow
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements-integration.in
     #   -r requirements.txt
-    #   databricks-cli
+    #   databricks-sdk
     #   docker
     #   hvac
     #   kubernetes
     #   macaroonbakery
-    #   mlflow
+    #   mlflow-skinny
     #   requests-oauthlib
     #   serialized-data-interface
-requests-oauthlib==1.3.1
-    # via kubernetes
+requests-oauthlib==2.0.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
 rsa==4.9
-    # via google-auth
-ruamel-yaml==0.17.32
+    # via
+    #   -r requirements.txt
+    #   google-auth
+ruamel-yaml==0.18.6
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via
     #   -r requirements.txt
     #   ruamel-yaml
-scikit-learn==1.3.0
+scikit-learn==1.3.2
     # via mlflow
 scipy==1.10.1
     # via
@@ -358,80 +420,86 @@ serialized-data-interface==0.7.0
     #   charmed-kubeflow-chisme
 six==1.16.0
     # via
-    #   asttokens
-    #   databricks-cli
-    #   google-auth
+    #   -r requirements.txt
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-    #   querystring-parser
-smmap==5.0.0
+smmap==5.0.1
     # via gitdb
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   -r requirements.txt
     #   anyio
-    #   httpcore
-    #   httpx
-sqlalchemy==2.0.20
+sqlalchemy==2.0.36
     # via
     #   alembic
     #   mlflow
-sqlparse==0.4.4
-    # via mlflow
-stack-data==0.6.2
+sqlparse==0.5.2
+    # via mlflow-skinny
+stack-data==0.6.3
     # via ipython
-tabulate==0.9.0
-    # via databricks-cli
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-threadpoolctl==3.2.0
+threadpoolctl==3.5.0
     # via scikit-learn
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
-    # via juju
-traitlets==5.9.0
+    # via
+    #   -r requirements.txt
+    #   juju
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
+    #   -r requirements.txt
     #   alembic
+    #   anyio
+    #   graphene
+    #   graphql-core
     #   ipython
+    #   juju
+    #   multidict
+    #   opentelemetry-sdk
     #   sqlalchemy
     #   typing-inspect
 typing-inspect==0.9.0
-    # via juju
-tzdata==2023.3
+    # via
+    #   -r requirements.txt
+    #   juju
+tzdata==2024.2
     # via pandas
-urllib3==2.0.4
+urllib3==2.2.3
     # via
     #   -r requirements.txt
     #   docker
     #   kubernetes
     #   requests
-wcwidth==0.2.6
+wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.6.3
+websocket-client==1.8.0
     # via
     #   -r requirements.txt
-    #   docker
     #   kubernetes
     #   ops
-websockets==8.1
-    # via juju
-werkzeug==2.3.7
+websockets==13.1
+    # via
+    #   -r requirements.txt
+    #   juju
+werkzeug==3.0.6
     # via flask
-yarl==1.9.2
+wrapt==1.17.0
+    # via deprecated
+yarl==1.15.2
     # via aiohttp
-zipp==3.16.2
+zipp==3.20.2
     # via
     #   -r requirements.txt
     #   importlib-metadata

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,25 +4,25 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.3.0
+black==24.8.0
     # via -r requirements-fmt.txt
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements-fmt.txt
     #   black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.txt
 mccabe==0.7.0
     # via flake8
@@ -30,32 +30,32 @@ mypy-extensions==1.0.0
     # via
     #   -r requirements-fmt.txt
     #   black
-packaging==23.1
+packaging==24.2
     # via
     #   -r requirements-fmt.txt
     #   black
-pathspec==0.11.1
+pathspec==0.12.1
     # via
     #   -r requirements-fmt.txt
     #   black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.5.3
+platformdirs==4.3.6
     # via
     #   -r requirements-fmt.txt
     #   black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   -r requirements-fmt.txt
     #   black
     #   pyproject-flake8
-typing-extensions==4.6.3
+typing-extensions==4.12.2
     # via
     #   -r requirements-fmt.txt
     #   black

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -4,56 +4,86 @@
 #
 #    pip-compile requirements-unit.in
 #
-anyio==4.0.0
+anyio==4.5.2
     # via
     #   -r requirements.txt
-    #   httpcore
-attrs==23.1.0
+    #   httpx
+attrs==24.2.0
     # via
     #   -r requirements.txt
     #   jsonschema
-certifi==2023.7.22
+backports-strenum==1.3.1
+    # via
+    #   -r requirements.txt
+    #   juju
+bcrypt==4.2.1
+    # via
+    #   -r requirements.txt
+    #   paramiko
+cachetools==5.5.0
+    # via
+    #   -r requirements.txt
+    #   google-auth
+certifi==2024.8.30
     # via
     #   -r requirements.txt
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.17.1
+    # via
+    #   -r requirements.txt
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.txt
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via
     #   -r requirements.txt
     #   requests
-coverage==7.3.1
+coverage==7.6.1
     # via -r requirements-unit.in
+cryptography==44.0.0
+    # via
+    #   -r requirements.txt
+    #   paramiko
 deepdiff==6.2.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via
     #   -r requirements.txt
     #   anyio
     #   pytest
+google-auth==2.36.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
 h11==0.14.0
     # via
     #   -r requirements.txt
     #   httpcore
-httpcore==0.18.0
+httpcore==1.0.7
     # via
     #   -r requirements.txt
     #   httpx
-httpx==0.25.0
+httpx==0.28.0
     # via
     #   -r requirements.txt
     #   lightkube
-idna==3.4
+hvac==2.3.0
+    # via
+    #   -r requirements.txt
+    #   juju
+idna==3.10
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.5
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -67,21 +97,42 @@ jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-lightkube==0.14.0
+juju==3.6.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-lightkube-models==1.28.1.4
+kubernetes==30.1.0
+    # via
+    #   -r requirements.txt
+    #   juju
+lightkube==0.15.5
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
+lightkube-models==1.31.1.8
     # via
     #   -r requirements.txt
     #   lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via
+    #   -r requirements.txt
+    #   juju
+markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements.txt
+    #   typing-inspect
+oauthlib==3.2.2
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   requests-oauthlib
 oci-image==1.0.0
     # via -r requirements.txt
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -90,42 +141,104 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   deepdiff
-packaging==23.1
-    # via pytest
+packaging==24.2
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pytest
+paramiko==3.5.0
+    # via
+    #   -r requirements.txt
+    #   juju
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements.txt
     #   jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pyrsistent==0.19.3
+protobuf==5.29.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via
+    #   -r requirements.txt
+    #   google-auth
+pycparser==2.22
+    # via
+    #   -r requirements.txt
+    #   cffi
+pymacaroons==0.13.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pynacl==1.5.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==7.4.2
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-lazy-fixture
     #   pytest-mock
 pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
-pytest-mock==3.11.1
+pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
+    #   kubernetes
+pytz==2024.2
+    # via
+    #   -r requirements.txt
+    #   pyrfc3339
+pyyaml==6.0.2
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements.txt
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
     #   serialized-data-interface
-ruamel-yaml==0.17.32
+requests-oauthlib==2.0.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+rsa==4.9
+    # via
+    #   -r requirements.txt
+    #   google-auth
+ruamel-yaml==0.18.6
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via
     #   -r requirements.txt
     #   ruamel-yaml
@@ -133,27 +246,52 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   -r requirements.txt
     #   anyio
-    #   httpcore
-    #   httpx
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via pytest
-urllib3==2.0.4
+toposort==1.10
     # via
     #   -r requirements.txt
+    #   juju
+typing-extensions==4.12.2
+    # via
+    #   -r requirements.txt
+    #   anyio
+    #   juju
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via
+    #   -r requirements.txt
+    #   juju
+urllib3==2.2.3
+    # via
+    #   -r requirements.txt
+    #   kubernetes
     #   requests
-websocket-client==1.6.3
+websocket-client==1.8.0
     # via
     #   -r requirements.txt
+    #   kubernetes
     #   ops
-zipp==3.16.2
+websockets==13.1
+    # via
+    #   -r requirements.txt
+    #   juju
+zipp==3.20.2
     # via
     #   -r requirements.txt
     #   importlib-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,87 +4,175 @@
 #
 #    pip-compile requirements.in
 #
-anyio==4.0.0
-    # via httpcore
-attrs==23.1.0
+anyio==4.5.2
+    # via httpx
+attrs==24.2.0
     # via jsonschema
-certifi==2023.7.22
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.18.0
+httpcore==1.0.7
     # via httpx
-httpx==0.25.0
+httpx==0.28.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.6.0.0
     # via charmed-kubeflow-chisme
-lightkube-models==1.28.1.4
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.5
+    # via charmed-kubeflow-chisme
+lightkube-models==1.31.1.8
     # via
     #   -r requirements.in
     #   lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.14.0
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pyrsistent==0.19.3
+protobuf==5.29.0
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   -r requirements.in
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
+tenacity==9.0.0
+    # via charmed-kubeflow-chisme
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
     # via
     #   anyio
-    #   httpcore
-    #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.3
-    # via ops
-zipp==3.16.2
+    #   juju
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/tests/integration/manifests-tester/requirements.txt
+++ b/tests/integration/manifests-tester/requirements.txt
@@ -1,3 +1,0 @@
-ops
-pyyaml
-serialized-data-interface

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]


### PR DESCRIPTION
* Pin pip to 24.2 due to https://github.com/jazzband/pip-tools/issues/2131
* Update python dependencies using 'tox -e update-requirements'

Ref canonical/bundle-kubeflow#1177