### PR TITLE
Add matrix for testing multiple microk8s versions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,6 +64,11 @@ jobs:
   integration:
     name: Integration Test (build and deploy)
     runs-on: ubuntu-20.04
+    matrix:
+      # We test with highest and lowest supported versions of k8s
+      microk8s-versions:
+        - 1.29-strict/stable
+        - 1.31-strict/stable
 
     steps:
     - name: Check out repo
@@ -73,7 +78,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.31-strict/stable
+        channel: ${{ matrix.microk8s-versions }}
         juju-channel: 3.6/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
         charmcraft-channel: 3.x/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # We test with highest and lowest supported versions of k8s
+        # We test with the highest supported version on every supported release
         microk8s-versions:
           - 1.29-strict/stable
           - 1.31-strict/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,11 +64,12 @@ jobs:
   integration:
     name: Integration Test (build and deploy)
     runs-on: ubuntu-20.04
-    matrix:
-      # We test with highest and lowest supported versions of k8s
-      microk8s-versions:
-        - 1.29-strict/stable
-        - 1.31-strict/stable
+    strategy:
+      matrix:
+        # We test with highest and lowest supported versions of k8s
+        microk8s-versions:
+          - 1.29-strict/stable
+          - 1.31-strict/stable
 
     steps:
     - name: Check out repo


### PR DESCRIPTION
This PR adds a matrix in the `integrate.yaml` workflow to test multiple versions of `microk8s`. We do a similar thing in [istio-operators](https://github.com/canonical/istio-operators/blob/2eb17b38accd5336a2f0f8a0d9343b6cc6630717/.github/workflows/ci.yaml#L105-L107).

We do this because we will use this track for both CKF 1.9 and CKF 1.10.