### PR TITLE
PoC: Support Roles and RoleBindings

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,3 +22,7 @@ provides:
     interface: kubernetes_manifest
   pod-defaults:
     interface: kubernetes_manifest
+  roles:
+    interface: kubernetes_manifest
+  role-bindings:
+    interface: kubernetes_manifest

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,6 +25,8 @@ DISPATCHER_RESOURCES_PATH = "/app/resources"
 PODDEFAULTS_RELATION_NAME = "pod-defaults"
 SECRETS_RELATION_NAME = "secrets"
 SERVICEACCOUNTS_RELATION_NAME = "service-accounts"
+ROLES_RELATION_NAME = "roles"
+ROLEBINDINGS_RELATION_NAME = "role-bindings"
 
 
 class ResourceDispatcherOperator(CharmBase):
@@ -71,6 +73,12 @@ class ResourceDispatcherOperator(CharmBase):
         self._secrets_manifests_provider = KubernetesManifestsProvider(
             charm=self, relation_name=SECRETS_RELATION_NAME
         )
+        self._roles_manifests_provider = KubernetesManifestsProvider(
+            charm=self, relation_name=ROLES_RELATION_NAME
+        )
+        self._role_bindings_manifests_provider = KubernetesManifestsProvider(
+            charm=self, relation_name=ROLEBINDINGS_RELATION_NAME
+        )
         self._serviceaccounts_manifests_provider = KubernetesManifestsProvider(
             charm=self, relation_name=SERVICEACCOUNTS_RELATION_NAME
         )
@@ -79,6 +87,8 @@ class ResourceDispatcherOperator(CharmBase):
             self._poddefaults_manifests_provider,
             self._secrets_manifests_provider,
             self._serviceaccounts_manifests_provider,
+            self._roles_manifests_provider,
+            self._role_bindings_manifests_provider,
         ]:
             self.framework.observe(provider.on.updated, self._on_event)
 
@@ -101,6 +111,16 @@ class ResourceDispatcherOperator(CharmBase):
     def service_accounts_manifests_provider(self):
         """Returns the KubernetesManifestsProvider for Service Accounts"""
         return self._service_accounts_manifests_provider
+
+    @property
+    def roles_manifests_provider(self):
+        """Returns the KubernetesManifestsProvider for Service Accounts"""
+        return self._roles_manifests_provider
+
+    @property
+    def role_bindings_manifests_provider(self):
+        """Returns the KubernetesManifestsProvider for Service Accounts"""
+        return self._role_bindings_manifests_provider
 
     @property
     def _resource_dispatcher_operator_layer(self) -> Layer:
@@ -260,6 +280,14 @@ class ResourceDispatcherOperator(CharmBase):
             self._update_manifests(
                 self._poddefaults_manifests_provider,
                 f"{DISPATCHER_RESOURCES_PATH}/{PODDEFAULTS_RELATION_NAME}",
+            )
+            self._update_manifests(
+                self._roles_manifests_provider,
+                f"{DISPATCHER_RESOURCES_PATH}/{ROLES_RELATION_NAME}",
+            )
+            self._update_manifests(
+                self._role_bindings_manifests_provider,
+                f"{DISPATCHER_RESOURCES_PATH}/{ROLEBINDINGS_RELATION_NAME}",
             )
         except ErrorWithStatus as err:
             self.model.unit.status = err.status

--- a/src/templates/decorator-controller.yaml.j2
+++ b/src/templates/decorator-controller.yaml.j2
@@ -22,6 +22,14 @@ spec:
     resource: poddefaults
     updateStrategy:
       method: InPlace
+  - apiVersion: rbac.authorization.k8s.io/v1
+    resource: roles
+    updateStrategy:
+      method: InPlace
+  - apiVersion: rbac.authorization.k8s.io/v1
+    resource: rolebindings
+    updateStrategy:
+      method: InPlace
   resyncPeriodSeconds: 10
   hooks:
     sync:


### PR DESCRIPTION
### Context
Support applying Roles and RoleBindings by adding two extra endpoints `roles` and `role-bindings`.

This PR works with:
* https://github.com/canonical/resource-dispatcher-image/pull/35
* https://github.com/canonical/kserve-operators/pull/330

It also requires the following change in [metacontroller-operator](https://github.com/canonical/metacontroller-operator/) charm
```diff
diff --git a/src/files/manifests/metacontroller-rbac.yaml b/src/files/manifests/metacontroller-rbac.yaml
index 0042b53..b6532df 100644
--- a/src/files/manifests/metacontroller-rbac.yaml
+++ b/src/files/manifests/metacontroller-rbac.yaml
@@ -58,6 +58,19 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles          # needed for resource dispatcher
+  - rolebindings  # needed for resource dispatcher
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - apps
   resources:
```

### Results
Steps are
1. deploy modified versions of resource-dispatcher, kserve-controller, metacontroller-operator and dependencies (istio, kubeflow-profiles, kubeflow-roles, knative-serving, knative-operator, admission-webhook, minio)
2. Add all `kubernetes_manifests` relations between kserve-controller and resource-dispatcher (don't forget to relate kserve-controller to minio too)
3. Create two profiles (`my-profile` and `orfeas`)
4. The expected results are:
Secrets (`-orfeas-only` secret should exist only in namespace `orfeas`):
```
$ kubectl get secrets -norfeas
NAME                               TYPE     DATA   AGE
kserve-controller-s3               Opaque   2      123m
kserve-controller-s3-orfeas-only   Opaque   2      98m
$ kubectl get secrets -nmy-profile
NAME                   TYPE     DATA   AGE
kserve-controller-s3   Opaque   2      123m
```
RoleBindings (they should be the same):
```
$ kg rolebinding -n orfeas                           
NAME                 ROLE                         AGE
basic-role-binding   Role/basic-role              124m
default-editor       ClusterRole/kubeflow-edit    124m
default-viewer       ClusterRole/kubeflow-view    124m
namespaceAdmin       ClusterRole/kubeflow-admin   124m
$ kg rolebinding -nmy-profile
NAME                 ROLE                         AGE
basic-role-binding   Role/basic-role              124m
default-editor       ClusterRole/kubeflow-edit    124m
default-viewer       ClusterRole/kubeflow-view    124m
namespaceAdmin       ClusterRole/kubeflow-admin   124m
```
Roles (they should be the same):
```
$ kg roles -norfeas          
NAME         CREATED AT
basic-role   2025-04-15T12:56:25Z
$ kg roles -nmy-profile
NAME         CREATED AT
basic-role   2025-04-15T12:56:28Z

```