### PR TITLE
fix: remove tmate session in CI workflow

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -96,8 +96,3 @@ jobs:
     - name: Get operator logs
       run: kubectl logs --tail 100 -ntesting -loperator.juju.is/name=resource-dispatcher
       if: failure()
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: failure()
-      timeout-minutes: 40


### PR DESCRIPTION
Removes tmate session from integrate.yaml to avoid the job running for 40 mins in failure cases every time.