### PR TITLE
fix: Properly pass CHARMCRAFT_CREDENTIALS secret

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.3.0
         with:
-          credentials: "${{ secrets.charmcraft-credentials }}"
+          credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   lint:


### PR DESCRIPTION
This PR follows https://github.com/canonical/resource-dispatcher/pull/152 to properly use the `CHARMCRAFT_CREDENTIALS` secret in the CI.