### PR TITLE
fix: Properly pass `CHARMCRAFT_CREDENTIALS` on `on_push.yaml`

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
     secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:


### PR DESCRIPTION
This PR follows #152, #155 to align the name of `CHARMCRAFT_CREDENTIALS` on `on_push.yaml`