### PR TITLE
[PRA-90] Add feature to filter out manifests that are scoped to a namespace

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: docker.io/charmedkubeflow/resource-dispatcher:3.1-19fc3ab
+    upstream-source: docker.io/bikalpadhakalcanonical/resource-dispatcher-image:bikalpa1
 provides:
   provide-cmr-mesh:
     interface: cross_model_mesh

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: docker.io/bikalpadhakalcanonical/resource-dispatcher-image:bikalpa1
+    upstream-source: docker.io/bikalpadhakalcanonical/resource-dispatcher-image:bikalpa2
 provides:
   provide-cmr-mesh:
     interface: cross_model_mesh

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: docker.io/bikalpadhakalcanonical/resource-dispatcher-image:bikalpa2
+    upstream-source: docker.io/charmedkubeflow/resource-dispatcher:3.2-4fb4dfa
 provides:
   provide-cmr-mesh:
     interface: cross_model_mesh

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,7 +108,7 @@ def secondary_namespace(lightkube_client: lightkube.Client):
 
     yield obj.metadata.name
 
-    delete_all_from_yaml(yaml_text, lightkube_client)
+    delete_all_from_yaml(yaml.safe_dump(namespace), lightkube_client)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,6 +13,7 @@ import lightkube
 import pytest
 import yaml
 from lightkube import codecs
+from lightkube.resources.core_v1 import Namespace
 
 from .helpers import delete_all_from_yaml, get_or_build_charm, safe_load_file_to_text
 
@@ -28,6 +29,7 @@ MANIFESTS_TESTER_NO_SECRET_CHARM_PATH = Path(
 
 NAMESPACE_MANIFEST_FILE = "./tests/integration/resources/namespace.yaml"
 TESTING_LABELS = ["user.kubeflow.org/enabled"]  # Might be more than one in the future
+SECONDARY_TEST_NAMESPACE = "test-namespace-resource-dispatcher-2"
 
 
 def pytest_addoption(parser):
@@ -92,6 +94,26 @@ def namespace(lightkube_client: lightkube.Client):
     yield obj.metadata.name
 
     delete_all_from_yaml(yaml_text, lightkube_client)
+
+
+@pytest.fixture(scope="module")
+def secondary_namespace(lightkube_client: lightkube.Client):
+    yaml_text = safe_load_file_to_text(NAMESPACE_MANIFEST_FILE)
+    namespace = yaml.safe_load(yaml_text)
+    namespace["metadata"]["name"] = SECONDARY_TEST_NAMESPACE
+    for label in TESTING_LABELS:
+        namespace["metadata"]["labels"][label] = "true"
+    obj = codecs.from_dict(namespace)
+    lightkube_client.apply(obj)
+
+    yield obj.metadata.name
+
+    delete_all_from_yaml(yaml_text, lightkube_client)
+
+
+@pytest.fixture(scope="module")
+def profile_namespaces(namespace: str, secondary_namespace: str) -> tuple[str, str]:
+    return (namespace, secondary_namespace)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -17,6 +17,7 @@ RESOURCE_DISPATCHER_CHARM_NAME = "resource-dispatcher"
 RESOURCE_DISPATCHER_NO_SECRET_REVISION = (
     402  # Revision that still uses kubernetes_manifests lib 0.1
 )
+RESOURCE_DISPATCHER_NO_SECRET_OCI_IMAGE = "charmedkubeflow/resource-dispatcher:1.0-22.04"  # Image before feature for roles and rolebindings were added
 
 
 def safe_load_file_to_text(filename: str) -> str:

--- a/tests/integration/manifests-tester-no-secret/src/manifests1/secrets/secret1.yaml
+++ b/tests/integration/manifests-tester-no-secret/src/manifests1/secrets/secret1.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mlpipeline-minio-artifact3
+  namespace: test-namespace-resource-dispatcher
   labels:
     user.kubeflow.org/enabled: "true"
 stringData:

--- a/tests/integration/manifests-tester/src/manifests1/secrets/secret1.yaml
+++ b/tests/integration/manifests-tester/src/manifests1/secrets/secret1.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mlpipeline-minio-artifact
+  namespace: test-namespace-resource-dispatcher
   labels:
     user.kubeflow.org/enabled: "true"
 stringData:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -63,6 +63,10 @@ TESTER2_ROLE_NAMES = ["test2-role"]
 TESTER1_ROLEBINDING_NAMES = ["test1-rolebinding"]
 TESTER2_ROLEBINDING_NAMES = ["test2-rolebinding"]
 
+PROFILE_SCOPED_SECRET1 = MINIO_SECRET_NAME1
+PROFILE_SCOPED_SECRET2 = MINIO_SECRET_NAME3
+PROFILE_AGNOSTIC_SECRET1 = "mlpipeline-minio-artifact2"
+PROFILE_AGNOSTIC_SECRET2 = "mlpipeline-minio-artifact4"
 
 PodDefault = create_namespaced_resource("kubeflow.org", "v1alpha1", "PodDefault", "poddefaults")
 
@@ -151,7 +155,12 @@ def test_build_and_deploy_tester_charms(
     service_account_name_1: str,
     service_account_name_2: str,
 ):
-    """Deploy manifest-tester-no-secret charm, that uses kubernetes_manifest lib 0.1."""
+    """Deploy tester charms.
+
+    The parametrized test will first deploy the manifest-tester charm with the new library that supports secrets,
+    and then deploy the manifest-tester-no-secret charm with the old library that does not support secrets.
+    This allows us to test both types of charms in the subsequent tests.
+    """
     tester_charm = request.getfixturevalue(tester_charm_fixture)
     juju.deploy(
         charm=tester_charm,
@@ -307,6 +316,50 @@ def test_manifests_created_from_both_tester_charms(
     for name in expected_tester_rolebindings_1 + expected_tester_rolebindings_2:
         rb = lightkube_client.get(RoleBinding, name, namespace=namespace)
         assert rb != None
+
+
+@pytest.mark.parametrize(
+    "profile_scoped_secret,profile_agnostic_secret",
+    [
+        (PROFILE_SCOPED_SECRET1, PROFILE_AGNOSTIC_SECRET1),
+        (PROFILE_SCOPED_SECRET2, PROFILE_AGNOSTIC_SECRET2),
+    ],
+)
+def test_manifest_namespace_scoping(
+    lightkube_client: lightkube.Client,
+    profile_namespaces: tuple[str, str],
+    profile_scoped_secret: str,
+    profile_agnostic_secret: str,
+) -> None:
+    """Validate pinned manifests apply to one namespace while unpinned manifests apply to all profiles."""
+    primary_namespace, secondary_namespace = profile_namespaces
+
+    time.sleep(
+        30
+    )  # sync can take up to 10 seconds for reconciliation loop to trigger (+ time to create namespaces)
+
+    # pinned manifests are applied only to the namespace explicitly set in metadata.namespace
+    pinned_secret = lightkube_client.get(
+        Secret, profile_scoped_secret, namespace=primary_namespace
+    )
+    assert pinned_secret != None
+
+    # logger.error("sleeping...")
+    # time.sleep(10 * 60)
+
+    with pytest.raises(ApiError) as e_info:
+        lightkube_client.get(Secret, profile_scoped_secret, namespace=secondary_namespace)
+    assert "not found" in str(e_info)
+
+    # manifests without metadata.namespace are applied to all profile namespaces
+    unpinned_secret_primary = lightkube_client.get(
+        Secret, profile_agnostic_secret, namespace=primary_namespace
+    )
+    unpinned_secret_secondary = lightkube_client.get(
+        Secret, profile_agnostic_secret, namespace=secondary_namespace
+    )
+    assert unpinned_secret_primary != None
+    assert unpinned_secret_secondary != None
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -64,6 +64,10 @@ TESTER2_ROLE_NAMES = ["test2-role"]
 TESTER1_ROLEBINDING_NAMES = ["test1-rolebinding"]
 TESTER2_ROLEBINDING_NAMES = ["test2-rolebinding"]
 
+PROFILE_SCOPED_SECRET1 = MINIO_SECRET_NAME1
+PROFILE_SCOPED_SECRET2 = MINIO_SECRET_NAME3
+PROFILE_AGNOSTIC_SECRET1 = "mlpipeline-minio-artifact2"
+PROFILE_AGNOSTIC_SECRET2 = "mlpipeline-minio-artifact4"
 
 PodDefault = create_namespaced_resource("kubeflow.org", "v1alpha1", "PodDefault", "poddefaults")
 
@@ -174,7 +178,12 @@ def test_build_and_deploy_tester_charms(
     service_account_name_1: str,
     service_account_name_2: str,
 ):
-    """Deploy manifest-tester-no-secret charm, that uses kubernetes_manifest lib 0.1."""
+    """Deploy tester charms.
+
+    The parametrized test will first deploy the manifest-tester charm with the new library that supports secrets,
+    and then deploy the manifest-tester-no-secret charm with the old library that does not support secrets.
+    This allows us to test both types of charms in the subsequent tests.
+    """
     tester_charm = request.getfixturevalue(tester_charm_fixture)
     juju.deploy(
         charm=tester_charm,
@@ -330,6 +339,47 @@ def test_manifests_created_from_both_tester_charms(
     for name in expected_tester_rolebindings_1 + expected_tester_rolebindings_2:
         rb = lightkube_client.get(RoleBinding, name, namespace=namespace)
         assert rb != None
+
+
+@pytest.mark.parametrize(
+    "profile_scoped_secret,profile_agnostic_secret",
+    [
+        (PROFILE_SCOPED_SECRET1, PROFILE_AGNOSTIC_SECRET1),
+        (PROFILE_SCOPED_SECRET2, PROFILE_AGNOSTIC_SECRET2),
+    ],
+)
+def test_manifest_namespace_scoping(
+    lightkube_client: lightkube.Client,
+    profile_namespaces: tuple[str, str],
+    profile_scoped_secret: str,
+    profile_agnostic_secret: str,
+) -> None:
+    """Validate pinned manifests apply to one namespace while unpinned manifests apply to all profiles."""
+    primary_namespace, secondary_namespace = profile_namespaces
+
+    time.sleep(
+        30
+    )  # sync can take up to 10 seconds for reconciliation loop to trigger (+ time to create namespaces)
+
+    # pinned manifests are applied only to the namespace explicitly set in metadata.namespace
+    pinned_secret = lightkube_client.get(
+        Secret, profile_scoped_secret, namespace=primary_namespace
+    )
+    assert pinned_secret != None
+
+    with pytest.raises(ApiError) as e_info:
+        lightkube_client.get(Secret, profile_scoped_secret, namespace=secondary_namespace)
+    assert "not found" in str(e_info)
+
+    # manifests without metadata.namespace are applied to all profile namespaces
+    unpinned_secret_primary = lightkube_client.get(
+        Secret, profile_agnostic_secret, namespace=primary_namespace
+    )
+    unpinned_secret_secondary = lightkube_client.get(
+        Secret, profile_agnostic_secret, namespace=secondary_namespace
+    )
+    assert unpinned_secret_primary != None
+    assert unpinned_secret_secondary != None
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_upgrade_erronous_path.py
+++ b/tests/integration/test_upgrade_erronous_path.py
@@ -212,6 +212,9 @@ def test_profile_scoped_secrets(
     juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
 ):
     """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
+    time.sleep(
+        30
+    )  # sync can take up to 10 seconds for reconciliation loop to trigger (+ time to create namespace)
     with pytest.raises(ApiError) as e_info:
         lightkube_client.get(Secret, MINIO_SECRET_NAME_NEW, namespace=namespace)
     assert "not found" in str(e_info)

--- a/tests/integration/test_upgrade_erronous_path.py
+++ b/tests/integration/test_upgrade_erronous_path.py
@@ -28,6 +28,7 @@ from lightkube.resources.rbac_authorization_v1 import Role, RoleBinding
 from .charms_dependencies import METACONTROLLER_OPERATOR, RESOURCE_DISPATCHER_NO_SECRET
 from .helpers import (
     RESOURCE_DISPATCHER_CHARM_NAME,
+    RESOURCE_DISPATCHER_NO_SECRET_OCI_IMAGE,
     RESOURCE_DISPATCHER_NO_SECRET_REVISION,
     deploy_k8s_resources,
 )
@@ -85,6 +86,7 @@ def test_deploy_resource_dispatcher_charm(juju: jubilant.Juju):
         app=RESOURCE_DISPATCHER_CHARM_NAME,
         channel=RESOURCE_DISPATCHER_NO_SECRET.channel,
         revision=RESOURCE_DISPATCHER_NO_SECRET_REVISION,
+        resources={"oci-image": RESOURCE_DISPATCHER_NO_SECRET_OCI_IMAGE},
         trust=True,
     )
     status = juju.wait(
@@ -99,7 +101,7 @@ def test_deploy_resource_dispatcher_charm(juju: jubilant.Juju):
 
 
 def test_build_and_deploy_tester_charm(juju: jubilant.Juju, manifest_tester_no_secret_charm: Path):
-    """Deploy manifest-tester charm, that uses kubernetes_manifest lib 0.2."""
+    """Deploy manifest-tester charm, that uses kubernetes_manifest lib 0.1."""
     juju.deploy(
         charm=manifest_tester_no_secret_charm,
         app=MANIFEST_TESTER_CHARM,
@@ -206,6 +208,15 @@ def test_upgrade_resource_dispatcher(juju: jubilant.Juju, resource_dispatcher_ch
     )
 
 
+def test_profile_scoped_secrets(
+    juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
+):
+    """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
+    with pytest.raises(ApiError) as e_info:
+        lightkube_client.get(Secret, MINIO_SECRET_NAME_NEW, namespace=namespace)
+    assert "not found" in str(e_info)
+
+
 def test_integrate_new_relations_with_resource_dispatcher(
     juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
 ):
@@ -250,6 +261,7 @@ def test_change_in_manifest_reflected_again(
 
     with pytest.raises(ApiError) as e_info:
         lightkube_client.get(ServiceAccount, SERVICE_ACCOUNT_NAME, namespace=namespace)
+    assert "not found" in str(e_info)
     service_account = lightkube_client.get(
         ServiceAccount, SERVICE_ACCOUNT_NAME_2, namespace=namespace
     )

--- a/tests/integration/test_upgrade_erronous_path.py
+++ b/tests/integration/test_upgrade_erronous_path.py
@@ -45,7 +45,7 @@ MINIO_SECRET_NAME_NEW = "mlpipeline-minio-artifact"
 SERVICE_ACCOUNT_NAME = MANIFESTS_TESTER_CONFIG["options"]["service_account_name"]["default"]
 SERVICE_ACCOUNT_NAME_2 = SERVICE_ACCOUNT_NAME + "-2"
 SERVICE_ACCOUNT_NAME_3 = SERVICE_ACCOUNT_NAME + "-3"
-
+PROFILE_SCOPED_SECRET = MINIO_SECRET_NAME_NEW
 
 TESTER_SECRET_NAMES_OLD = ["mlpipeline-minio-artifact3", "seldon-rclone-secret3"]
 TESTER_SECRET_NAMES_NEW = ["mlpipeline-minio-artifact", "seldon-rclone-secret"]
@@ -208,18 +208,6 @@ def test_upgrade_resource_dispatcher(juju: jubilant.Juju, resource_dispatcher_ch
     )
 
 
-def test_profile_scoped_secrets(
-    juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
-):
-    """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
-    time.sleep(
-        30
-    )  # sync can take up to 10 seconds for reconciliation loop to trigger (+ time to create namespace)
-    with pytest.raises(ApiError) as e_info:
-        lightkube_client.get(Secret, MINIO_SECRET_NAME_NEW, namespace=namespace)
-    assert "not found" in str(e_info)
-
-
 def test_integrate_new_relations_with_resource_dispatcher(
     juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
 ):
@@ -269,3 +257,19 @@ def test_change_in_manifest_reflected_again(
         ServiceAccount, SERVICE_ACCOUNT_NAME_2, namespace=namespace
     )
     assert service_account != None
+
+
+def test_profile_scoped_secrets(
+    juju: jubilant.Juju, lightkube_client: lightkube.Client, profile_namespaces: tuple[str, str]
+):
+    """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
+    primary_profile, secondary_profile = profile_namespaces
+    time.sleep(
+        30
+    )  # sync can take up to 10 seconds for reconciliation loop to trigger (+ time to create namespace)
+    for name in TESTER_SECRET_NAMES_NEW:
+        secret = lightkube_client.get(Secret, name, namespace=primary_profile)
+        assert secret != None
+    with pytest.raises(ApiError) as e_info:
+        lightkube_client.get(Secret, PROFILE_SCOPED_SECRET, namespace=secondary_profile)
+    assert "not found" in str(e_info)

--- a/tests/integration/test_upgrade_happy_path.py
+++ b/tests/integration/test_upgrade_happy_path.py
@@ -41,7 +41,7 @@ MINIO_SECRET_NAME_NEW = "mlpipeline-minio-artifact"
 SERVICE_ACCOUNT_NAME = MANIFESTS_TESTER_CONFIG["options"]["service_account_name"]["default"]
 SERVICE_ACCOUNT_NAME_2 = SERVICE_ACCOUNT_NAME + "-2"
 SERVICE_ACCOUNT_NAME_3 = SERVICE_ACCOUNT_NAME + "-3"
-
+PROFILE_SCOPED_SECRET = MINIO_SECRET_NAME_NEW
 
 TESTER_SECRET_NAMES_OLD = ["mlpipeline-minio-artifact3", "seldon-rclone-secret3"]
 TESTER_SECRET_NAMES_NEW = ["mlpipeline-minio-artifact", "seldon-rclone-secret"]
@@ -205,15 +205,6 @@ def test_change_in_manifest_reflected(
     assert service_account != None
 
 
-def test_profile_scoped_secrets(
-    juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
-):
-    """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
-    with pytest.raises(ApiError) as e_info:
-        lightkube_client.get(Secret, MINIO_SECRET_NAME_NEW, namespace=namespace)
-    assert "not found" in str(e_info)
-
-
 def test_upgrade_tester_charm(juju: jubilant.Juju, manifest_tester_charm: Path):
     """Upgrade manifest-tester charm in-place to the implementation that uses kubernetes_manifest v0.2."""
     juju.refresh(
@@ -290,3 +281,19 @@ def test_change_in_manifest_reflected_again(
         ServiceAccount, SERVICE_ACCOUNT_NAME_3, namespace=namespace
     )
     assert service_account != None
+
+
+def test_profile_scoped_secrets(
+    juju: jubilant.Juju, lightkube_client: lightkube.Client, profile_namespaces: tuple[str, str]
+):
+    """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
+    primary_profile, secondary_profile = profile_namespaces
+    time.sleep(
+        30
+    )  # sync can take up to 10 seconds for reconciliation loop to trigger (+ time to create namespace)
+    for name in TESTER_SECRET_NAMES_NEW:
+        secret = lightkube_client.get(Secret, name, namespace=primary_profile)
+        assert secret != None
+    with pytest.raises(ApiError) as e_info:
+        lightkube_client.get(Secret, PROFILE_SCOPED_SECRET, namespace=secondary_profile)
+    assert "not found" in str(e_info)

--- a/tests/integration/test_upgrade_happy_path.py
+++ b/tests/integration/test_upgrade_happy_path.py
@@ -24,6 +24,7 @@ from lightkube.resources.rbac_authorization_v1 import Role, RoleBinding
 from .charms_dependencies import METACONTROLLER_OPERATOR, RESOURCE_DISPATCHER_NO_SECRET
 from .helpers import (
     RESOURCE_DISPATCHER_CHARM_NAME,
+    RESOURCE_DISPATCHER_NO_SECRET_OCI_IMAGE,
     RESOURCE_DISPATCHER_NO_SECRET_REVISION,
     deploy_k8s_resources,
 )
@@ -81,6 +82,7 @@ def test_deploy_resource_dispatcher_charm(juju: jubilant.Juju):
         app=RESOURCE_DISPATCHER_CHARM_NAME,
         channel=RESOURCE_DISPATCHER_NO_SECRET.channel,
         revision=RESOURCE_DISPATCHER_NO_SECRET_REVISION,
+        resources={"oci-image": RESOURCE_DISPATCHER_NO_SECRET_OCI_IMAGE},
         trust=True,
     )
     status = juju.wait(
@@ -95,7 +97,7 @@ def test_deploy_resource_dispatcher_charm(juju: jubilant.Juju):
 
 
 def test_build_and_deploy_tester_charm(juju: jubilant.Juju, manifest_tester_no_secret_charm: Path):
-    """Deploy manifest-tester charm, that uses kubernetes_manifest lib 0.2."""
+    """Deploy manifest-tester charm, that uses kubernetes_manifest lib 0.1."""
     juju.deploy(
         charm=manifest_tester_no_secret_charm,
         app=MANIFEST_TESTER_CHARM,
@@ -201,6 +203,15 @@ def test_change_in_manifest_reflected(
         ServiceAccount, SERVICE_ACCOUNT_NAME_2, namespace=namespace
     )
     assert service_account != None
+
+
+def test_profile_scoped_secrets(
+    juju: jubilant.Juju, lightkube_client: lightkube.Client, namespace: str
+):
+    """Test that profile scoped secret (mlpipeline-minio-artifact) created previously by resource-dispatcher are removed."""
+    with pytest.raises(ApiError) as e_info:
+        lightkube_client.get(Secret, MINIO_SECRET_NAME_NEW, namespace=namespace)
+    assert "not found" in str(e_info)
 
 
 def test_upgrade_tester_charm(juju: jubilant.Juju, manifest_tester_charm: Path):


### PR DESCRIPTION
As of now, the `reosource-dispatcher` applies the manifests sent to it via different relations to **all** namespaces that match the label.

This PR adds a feature in the resource dispatcher (at the charm level) such that the resources that have `metadata.namespace` in them (meaning they are scoped to a specific namespace/profile) will only be applied to that specific namespace/profile. Only in cases where the manifest do not have `metadata.namespace` in it, will then they be applied to **all** profiles. 

The integration tests have also been updated to test this behavior.

The actual changes in the image level is done at: https://github.com/canonical/resource-dispatcher-image/pull/47

Higher level integration (with various components):
Integration with Data Kubeflow Integrator charm: https://github.com/canonical/data-kubeflow-integrator/pull/29
