### PR TITLE
fix: swap to use edge version for metacontroller

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -3,7 +3,7 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 METACONTROLLER_OPERATOR = CharmSpec(
-    charm="metacontroller-operator", channel="4.11/stable", trust=True
+    charm="metacontroller-operator", channel="4.11/edge", trust=True
 )
 RESOURCE_DISPATCHER_NO_SECRET = CharmSpec(
     charm="resource-dispatcher", channel="2.0/stable", trust=True


### PR DESCRIPTION
Tests seems to not be passing in CI on the release 