### PR TITLE
fix: reapply Pebble workload layer on pebble-ready and update-status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -218,10 +218,9 @@ class ResourceDispatcherOperator(CharmBase):
             self.logger.info("Not a leader, skipping setup")
             raise ErrorWithStatus("Waiting for leadership", WaitingStatus)
 
-    def _check_container(self, event: EventBase):
+    def _check_container(self):
         """Check if we can connect the container."""
         if not self.container.can_connect():
-            event.defer()
             raise ErrorWithStatus("Container is not ready", WaitingStatus)
 
     def _deploy_k8s_resources(self) -> None:
@@ -380,7 +379,7 @@ class ResourceDispatcherOperator(CharmBase):
         """Perform all required actions for the Charm."""
         try:
             self._check_leader()
-            self._check_container(event)
+            self._check_container()
             self._update_layer()
             self._update_manifests(
                 self._configmaps_manifests_provider,

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,9 +69,6 @@ class ResourceDispatcherOperator(CharmBase):
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.config_changed, self._on_event)
         self.framework.observe(self.on.remove, self._on_remove)
-        # Reapply the Pebble workload layer when the container becomes ready (initial start,
-        # restart, upgrade) and periodically via update-status, so that a lost/empty plan is
-        # repaired automatically (see: https://github.com/canonical/resource-dispatcher/issues/168).
         self.framework.observe(self.on.resource_dispatcher_pebble_ready, self._on_event)
         self.framework.observe(self.on.update_status, self._on_event)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,6 +69,11 @@ class ResourceDispatcherOperator(CharmBase):
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.config_changed, self._on_event)
         self.framework.observe(self.on.remove, self._on_remove)
+        # Reapply the Pebble workload layer when the container becomes ready (initial start,
+        # restart, upgrade) and periodically via update-status, so that a lost/empty plan is
+        # repaired automatically (see: https://github.com/canonical/resource-dispatcher/issues/168).
+        self.framework.observe(self.on.resource_dispatcher_pebble_ready, self._on_event)
+        self.framework.observe(self.on.update_status, self._on_event)
 
         port = ServicePort(
             port=self._service_port, targetPort=self._webserver_port, name=f"{self.app.name}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -393,6 +393,56 @@ class TestCharm:
         harness.charm.on.upgrade_charm.emit()
         deploy_k8s_resources.assert_called_once()
 
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    def test_pebble_ready_triggers_on_event(
+        self,
+        harness: Harness,
+        mock_lightkube_client: MagicMock,
+    ):
+        """The pebble-ready event applies the workload Pebble layer via _on_event."""
+        harness.begin()
+        # Sanity-check: the plan starts empty (no services configured).
+        assert harness.charm.container.get_plan().services == {}
+        harness.container_pebble_ready("resource-dispatcher")
+        assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    @patch("charm.ResourceDispatcherOperator._update_layer")
+    def test_update_status_triggers_reconciliation(
+        self,
+        update_layer: MagicMock,
+        harness: Harness,
+        mock_lightkube_client: MagicMock,
+    ):
+        """The update-status event triggers reconciliation (which reapplies the Pebble layer)."""
+        harness.begin()
+        harness.charm.on.update_status.emit()
+        update_layer.assert_called_once()
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    def test_update_status_recovers_empty_plan(
+        self,
+        harness: Harness,
+        mock_lightkube_client: MagicMock,
+    ):
+        """Regression test for GH#168: an empty Pebble plan is repaired via update-status."""
+        harness.begin()
+        # Simulate the reported failure mode: the container is running but its Pebble plan
+        # is empty (no workload service).
+        assert harness.charm.container.get_plan().services == {}
+        harness.charm.on.update_status.emit()
+        # After update-status, the workload service should be back in the plan.
+        assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
+
     @patch("charm.KubernetesResourceHandler")
     @patch(
         "charm.KubernetesServicePatch",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -397,22 +397,6 @@ class TestCharm:
         "charm.KubernetesServicePatch",
         lambda x, y, service_name, service_type, refresh_event: None,
     )
-    def test_pebble_ready_triggers_on_event(
-        self,
-        harness: Harness,
-        mock_lightkube_client: MagicMock,
-    ):
-        """The pebble-ready event applies the workload Pebble layer via _on_event."""
-        harness.begin()
-        # Sanity-check: the plan starts empty (no services configured).
-        assert harness.charm.container.get_plan().services == {}
-        harness.container_pebble_ready("resource-dispatcher")
-        assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
-
-    @patch(
-        "charm.KubernetesServicePatch",
-        lambda x, y, service_name, service_type, refresh_event: None,
-    )
     @patch("charm.ResourceDispatcherOperator._update_layer")
     def test_update_status_triggers_reconciliation(
         self,
@@ -420,10 +404,25 @@ class TestCharm:
         harness: Harness,
         mock_lightkube_client: MagicMock,
     ):
-        """The update-status event triggers reconciliation (which reapplies the Pebble layer)."""
+        """The update-status event triggers reconciliation"""
         harness.begin()
         harness.charm.on.update_status.emit()
         update_layer.assert_called_once()
+
+    @patch(
+        "charm.KubernetesServicePatch",
+        lambda x, y, service_name, service_type, refresh_event: None,
+    )
+    def test_pebble_ready_recovers_empty_plan(
+        self,
+        harness: Harness,
+        mock_lightkube_client: MagicMock,
+    ):
+        """Test that an empty Pebble plan is recovered via pebble-ready."""
+        harness.begin()
+        assert harness.charm.container.get_plan().services == {}
+        harness.container_pebble_ready("resource-dispatcher")
+        assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
 
     @patch(
         "charm.KubernetesServicePatch",
@@ -434,13 +433,10 @@ class TestCharm:
         harness: Harness,
         mock_lightkube_client: MagicMock,
     ):
-        """Regression test for GH#168: an empty Pebble plan is repaired via update-status."""
+        """Test that an empty Pebble plan is recovered via update-status."""
         harness.begin()
-        # Simulate the reported failure mode: the container is running but its Pebble plan
-        # is empty (no workload service).
         assert harness.charm.container.get_plan().services == {}
         harness.charm.on.update_status.emit()
-        # After update-status, the workload service should be back in the plan.
         assert harness.charm.container.get_plan().services == EXPECTED_SERVICE
 
     @patch("charm.KubernetesResourceHandler")


### PR DESCRIPTION
## Summary
- Trigger the `on_event` method on the following 2 events:
  - `resource_dispatcher_pebble_ready`
  - `update_status`
- Add three unit tests covering this exact behavior.

## Note
We are removing the `event.defer()` in `_check_container()`, since this goes against the pattern we have in our other charms. Since we now observe `update_status`, at worst this status will stay until the next call of `update-status`. See for example:
- [dex-auth-operator](https://github.com/canonical/dex-auth-operator/blob/4e59debbaa53cf0be4893c310cae26df519c3ef2/src/charm.py#L251-L253)
- [admission-webhook](https://github.com/canonical/admission-webhook-operator/blob/e8a685f8b15d2fa2701880f8b8e385a6e586f7e9/src/charm.py#L286-L295)
- [mlflow-operator](https://github.com/canonical/mlflow-operator/blob/a9c1e6b43f7b3104efc3d002c6ba576b75b1264b/src/charm.py#L602-L613)


Closes #168